### PR TITLE
Add copilot-assisted and gemini-assisted labels

### DIFF
--- a/labels.yml
+++ b/labels.yml
@@ -108,6 +108,12 @@
 - name: "claude-code-assisted"
   color: "d4c5f9"
   description: "PR created or assisted by Claude Code"
+- name: "copilot-assisted"
+  color: "1f6feb"
+  description: "PR created or assisted by GitHub Copilot"
+- name: "gemini-assisted"
+  color: "4285f4"
+  description: "PR created or assisted by Google Gemini"
 
 # Team
 - name: "team-ada"


### PR DESCRIPTION
## Summary
- Added `copilot-assisted` label (GitHub brand blue `1f6feb`) for PRs created or assisted by GitHub Copilot
- Added `gemini-assisted` label (Google brand blue `4285f4`) for PRs created or assisted by Google Gemini
- Complements the existing `claude-code-assisted` label

## Test plan
- [ ] Merge and verify the sync-labels workflow propagates both new labels to all repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)